### PR TITLE
Fix: Skip logging event to moesif if the response is html

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add the Moesif dependency to your project's pom.xml file:
 <dependency>
     <groupId>com.moesif.servlet</groupId>
     <artifactId>moesif-servlet</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.1</version>
 </dependency>
 ```
 
@@ -56,7 +56,7 @@ repositories {
 }
  
 dependencies {   
-    compile 'com.moesif.servlet:moesif-servlet:1.4.0'
+    compile 'com.moesif.servlet:moesif-servlet:1.5.1'
 }
 ```
 

--- a/moesif-servlet/pom.xml
+++ b/moesif-servlet/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.servlet</groupId>
   <artifactId>moesif-servlet</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <packaging>jar</packaging>
   <name>moesif-servlet</name>
   <description>Moesif SDK for Java Servlet to log and analyze API calls</description>
@@ -66,7 +66,7 @@
     <dependency>
 	  <groupId>com.fasterxml.jackson.core</groupId>
 	  <artifactId>jackson-databind</artifactId>
-	  <version>2.9.6</version>
+	  <version>2.9.8</version>
 	</dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -78,6 +78,11 @@
       <artifactId>commons-io</artifactId>
       <version>${commons-io.version}</version>
     </dependency>
+    <dependency>
+	    <groupId>org.apache.tomcat</groupId>
+	    <artifactId>catalina</artifactId>
+	    <version>6.0.16</version>
+	</dependency>
 
 
     <!-- testing -->

--- a/moesif-servlet/src/main/java/com/moesif/servlet/MoesifFilter.java
+++ b/moesif-servlet/src/main/java/com/moesif/servlet/MoesifFilter.java
@@ -272,7 +272,9 @@ public class MoesifFilter implements Filter {
 
     if(!(responseWrapper.delegate instanceof ResponseFacade)) {
     	
-    	if (responseWrapper.getHeaders().get("Content-Type").toLowerCase().contains("html")) {
+    	if (responseWrapper.getHeaders() != null &&
+    			!responseWrapper.getHeaders().isEmpty() &&
+    			responseWrapper.getHeaders().get("Content-Type").toLowerCase().contains("html")) {
     		if (debug) {
     			logger.warning("MoesifFilter was called for html response, skipping send Event to Moesif");	
     		}

--- a/moesif-servlet/src/main/java/com/moesif/servlet/wrappers/LoggingHttpServletResponseWrapper.java
+++ b/moesif-servlet/src/main/java/com/moesif/servlet/wrappers/LoggingHttpServletResponseWrapper.java
@@ -18,7 +18,7 @@ public class LoggingHttpServletResponseWrapper extends HttpServletResponseWrappe
 
   private final LoggingServletOutputStream loggingServletOutputStream = new LoggingServletOutputStream();
 
-  private final HttpServletResponse delegate;
+  public final HttpServletResponse delegate;
 
   public LoggingHttpServletResponseWrapper(HttpServletResponse response) {
     super(response);


### PR DESCRIPTION
Fix: Skip logging event to moesif if the response is html
Add: Extra validation for the request/response content
Update: Dependency version
Update: README.md
Bump version to 1.5.1