### PR TITLE
Javadocs - not currently building

### DIFF
--- a/moesif-springrequest/pom.xml
+++ b/moesif-springrequest/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.springrequest</groupId>
   <artifactId>moesif-springrequest</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
   <name>moesif-springrequest</name>
   <description>Moesif SDK for Java to log and analyze outgoing API calls</description>

--- a/moesif-springrequest/pom.xml
+++ b/moesif-springrequest/pom.xml
@@ -124,6 +124,21 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>

--- a/moesif-springrequest/src/main/java/com/moesif/springrequest/MoesifRequestConfiguration.java
+++ b/moesif-springrequest/src/main/java/com/moesif/springrequest/MoesifRequestConfiguration.java
@@ -5,28 +5,67 @@ import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
 public class MoesifRequestConfiguration {
+    /**
+     * Enable debug error reporting via console
+     */
     public boolean debug = false;
 
+    /**
+     * Return true if and only if the request should not be recorded to moesif
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return true if and only if the request should not be logged
+     */
     public boolean skip(HttpRequest request, ClientHttpResponse response) {
         return false;
     }
 
+    /**
+     * Allows data to be filtered
+     * eg: remove headers, mask credit card numbers
+     * @param eventModel event to be masked
+     * @return event to be sent
+     */
     public EventModel maskContent(EventModel eventModel) {
         return eventModel;
     }
 
+    /**
+     * If Moesif is unable to identify the user, custom logic can be defined here
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the user ID
+     */
     public String identifyUser(HttpRequest request, ClientHttpResponse response) {
         return null;
     }
 
+    /**
+     * If Moesif is unable to identify the session, custom logic can be defined here
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the Session Token
+     */
     public String getSessionToken(HttpRequest request, ClientHttpResponse response) {
         return null;
     }
 
+    /**
+     * Provide an API version
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the API Version
+     */
     public String getApiVersion(HttpRequest request, ClientHttpResponse response) {
         return null;
     }
 
+    /**
+     * Provide any extra attributes that should be associated with this request
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the metadata
+     */
     public Object getMetadata(HttpRequest request, ClientHttpResponse response) {
         return null;
     }

--- a/moesif-springrequest/src/main/java/com/moesif/springrequest/MoesifSpringRequestInterceptor.java
+++ b/moesif-springrequest/src/main/java/com/moesif/springrequest/MoesifSpringRequestInterceptor.java
@@ -37,6 +37,10 @@ public class MoesifSpringRequestInterceptor implements ClientHttpRequestIntercep
     private int ERROR_GATEWAY_TIMEOUT = 504;
     private int ERROR_BAD_GATEWAY = 502;
 
+    /**
+     * Constructor
+     * @param moesifApi API instance
+     */
     public MoesifSpringRequestInterceptor(MoesifAPIClient moesifApi) {
         this.moesifApi = moesifApi;
         this.config = new MoesifRequestConfiguration();
@@ -44,6 +48,10 @@ public class MoesifSpringRequestInterceptor implements ClientHttpRequestIntercep
         this.moesifApi.getAPI().setShouldSyncAppConfig(true);
     }
 
+    /**
+     * Constructor
+     * @param applicationId your Moesif App ID
+     */
     public MoesifSpringRequestInterceptor(String applicationId) {
         this.moesifApi = new MoesifAPIClient(applicationId);
         this.config = new MoesifRequestConfiguration();
@@ -51,11 +59,21 @@ public class MoesifSpringRequestInterceptor implements ClientHttpRequestIntercep
         this.moesifApi.getAPI().setShouldSyncAppConfig(true);
     }
 
+    /**
+     * Constructor
+     * @param moesifApi API instance
+     * @param config Override default behavior (masking of content, user identification, etc)
+     */
     public MoesifSpringRequestInterceptor(MoesifAPIClient moesifApi, MoesifRequestConfiguration config) {
         this(moesifApi);
         this.config = config;
     }
 
+    /**
+     * Constructor
+     * @param applicationId your Moesif App ID
+     * @param config Override default behavior (masking of content, user identification, etc)
+     */
     public MoesifSpringRequestInterceptor(String applicationId, MoesifRequestConfiguration config) {
         this(applicationId);
         this.config = config;
@@ -150,6 +168,14 @@ public class MoesifSpringRequestInterceptor implements ClientHttpRequestIntercep
             .build();
     }
 
+    /**
+     * Report the header, body, method, and URL of the request-response pair to moesif.com
+     * @param request the http request
+     * @param body the request body
+     * @param execution instance to make the HTTP request
+     * @return the HTTP response
+     * @throws IOException Throws if there's an error making the request
+     */
     @Override
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
         IOException queryException = null;


### PR DESCRIPTION
Do you know what's going on here? Couldn't find anything useful online and the error message is cryptic.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (attach-javadocs) on project moesif-springrequest: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module.
[ERROR]
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/Users/matt/workspace/moesif-servlet/moesif-springrequest/target/apidocs' dir.
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```