### PR TITLE
Upgrading moesifapi-java to v1.6.13 moesif-servlet v1.6.12 moesif-springrequest v1.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the Moesif dependency to your project's pom.xml file:
 <dependency>
     <groupId>com.moesif.servlet</groupId>
     <artifactId>moesif-servlet</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ Add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
 dependencies {   
-    compile 'com.moesif.servlet:moesif-servlet:1.6.11'
+    compile 'com.moesif.servlet:moesif-servlet:1.6.12'
 }
 ```
 

--- a/jersey-servlet-example/pom.xml
+++ b/jersey-servlet-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.moesif.servlet.jersey</groupId>
     <artifactId>jersey-servlet-example</artifactId>
     <packaging>war</packaging>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <name>jersey-servlet-example</name>
 
     <build>
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.1</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>1.7</source>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.moesif.servlet</groupId>
             <artifactId>moesif-servlet</artifactId>
-            <version>1.6.11</version>
+            <version>1.6.12</version>
         </dependency>
     </dependencies>
     <properties>

--- a/moesif-servlet/pom.xml
+++ b/moesif-servlet/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.servlet</groupId>
   <artifactId>moesif-servlet</artifactId>
-  <version>1.6.11</version>
+  <version>1.6.12</version>
   <packaging>jar</packaging>
   <name>moesif-servlet</name>
   <description>Moesif SDK for Java Servlet to log and analyze API calls</description>
@@ -45,7 +45,7 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-lang3.version>3.4</commons-lang3.version>
     <jackson.version>2.8.7</jackson.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.2</junit.version>
     <logback.version>1.1.3</logback.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <java.version>1.7</java.version>
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>com.moesif.api</groupId>
       <artifactId>moesifapi</artifactId>
-      <version>1.6.12</version>
+      <version>1.6.13</version>
     </dependency>
     <dependency>
 	  <groupId>com.fasterxml.jackson.core</groupId>
 	  <artifactId>jackson-databind</artifactId>
-	  <version>2.9.10.1</version>
+	  <version>2.9.10.8</version>
 	</dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/moesif-servlet/src/main/java/com/moesif/servlet/MoesifFilter.java
+++ b/moesif-servlet/src/main/java/com/moesif/servlet/MoesifFilter.java
@@ -1,10 +1,10 @@
 package com.moesif.servlet;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.*;
 import java.util.logging.Logger;
 import java.lang.*;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -190,8 +190,9 @@ public class MoesifFilter implements Filter {
         String responseConfigEtag = configApiResponse.getHeaders().get("x-moesif-config-etag");
 
         // Read the response body
-        ObjectMapper mapper = new ObjectMapper();
-        AppConfigModel newConfig = mapper.readValue(configApiResponse.getRawBody(), AppConfigModel.class);
+        InputStream respBodyIs = configApiResponse.getRawBody();
+        AppConfigModel newConfig = APIController.parseAppConfigModel(respBodyIs);
+        respBodyIs.close();
 
         this.appConfigModel = newConfig;
         this.cachedConfigEtag = responseConfigEtag;

--- a/moesif-springrequest/README.md
+++ b/moesif-springrequest/README.md
@@ -18,7 +18,7 @@ Add the Moesif dependency to your project's pom.xml file:
 <dependency>
     <groupId>com.moesif.springrequest</groupId>
     <artifactId>moesif-springrequest</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
 </dependency>
 ```
 
@@ -28,7 +28,7 @@ Add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
 dependencies {   
-    compile 'com.moesif.springrequest:moesif-springrequest:1.0.10'
+    compile 'com.moesif.springrequest:moesif-springrequest:1.0.11'
 }
 ```
 

--- a/moesif-springrequest/pom.xml
+++ b/moesif-springrequest/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.springrequest</groupId>
   <artifactId>moesif-springrequest</artifactId>
-  <version>1.0.10</version>
+  <version>1.0.11</version>
   <packaging>jar</packaging>
   <name>moesif-springrequest</name>
   <description>Moesif SDK for Java to log and analyze outgoing API calls</description>
@@ -45,7 +45,7 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-lang3.version>3.4</commons-lang3.version>
     <jackson.version>2.8.7</jackson.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.2</junit.version>
     <logback.version>1.1.3</logback.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <java.version>1.7</java.version>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.moesif.api</groupId>
       <artifactId>moesifapi</artifactId>
-      <version>1.6.12</version>
+      <version>1.6.13</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/servlet-example/pom.xml
+++ b/servlet-example/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.servlet</groupId>
   <artifactId>servlet-example</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <packaging>war</packaging>
   <name>servlet-example</name>
 
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet</artifactId>
-      <version>1.6.11</version>
+      <version>1.6.12</version>
     </dependency>
   </dependencies>
 

--- a/spark-servlet-example/pom.xml
+++ b/spark-servlet-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.moesif.servlet.spark</groupId>
     <artifactId>spark-servlet-example</artifactId>
     <packaging>war</packaging>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <name>spark-servlet-example</name>
 
     <build>
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.1</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>1.8</source>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.moesif.servlet</groupId>
             <artifactId>moesif-servlet</artifactId>
-            <version>1.6.11</version>
+            <version>1.6.12</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/spring-boot-servlet-example/pom.xml
+++ b/spring-boot-servlet-example/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>spring-boot-servlet-example</artifactId>
   <name>spring-boot-servlet-example</name>
   <packaging>war</packaging>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
 
   <properties>
     <springframework.version>5.2.9.RELEASE</springframework.version>
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>com.moesif.springrequest</groupId>
       <artifactId>moesif-springrequest</artifactId>
-      <version>1.0.10</version>
+      <version>1.0.11</version>
     </dependency>
 
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet</artifactId>
-      <version>1.6.11</version>
+      <version>1.6.12</version>
     </dependency>
 
 
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/spring-boot-starter-example/pom.xml
+++ b/spring-boot-starter-example/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>spring-boot-starter-example</artifactId>
   <name>spring-boot-starter-example</name>
   <packaging>war</packaging>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet</artifactId>
-      <version>1.6.11</version>
+      <version>1.6.12</version>
     </dependency>
   </dependencies>
 

--- a/springrequest-example/pom.xml
+++ b/springrequest-example/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>com.moesif.springrequestexample</groupId>
   <artifactId>springrequest-example</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <name>springrequest-example</name>
   <url>http://maven.apache.org</url>
 
@@ -19,7 +19,7 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-lang3.version>3.4</commons-lang3.version>
     <jackson.version>2.8.7</jackson.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.2</junit.version>
     <logback.version>1.1.3</logback.version>
     <mockito-core.version>1.10.19</mockito-core.version>
   </properties>
@@ -43,12 +43,12 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.10</version>
     </dependency>
     <dependency>
       <groupId>com.moesif.springrequest</groupId>
       <artifactId>moesif-springrequest</artifactId>
-      <version>1.0.10</version>
+      <version>1.0.11</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Updating `moesif-servlet` and `moesif-springrequest`:
* use moesifapi-java v1.6.13
* upgraded 8 pom.xml and corresponding readme
* minor improvements in `moesif-servlet` on deserializing config.