### PR TITLE
fix CVE-2021-45046 version bump only needed for publishing 1.6.15

### DIFF
--- a/moesif-servlet/pom.xml
+++ b/moesif-servlet/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.servlet</groupId>
   <artifactId>moesif-servlet</artifactId>
-  <version>1.6.14</version>
+  <version>1.6.15</version>
   <packaging>jar</packaging>
   <name>moesif-servlet</name>
   <description>Moesif SDK for Java Servlet to log and analyze API calls</description>


### PR DESCRIPTION
version bump only needed to address prior maven publish failure. bumping to 1.6.15
Contains updates for CVE-2021-45046 safety - log4j v 2.16.0 