### PR TITLE
Add java 17 support and devcontainer, update dependencies, fix warning

### DIFF
--- a/.devcontainer-java11/Dockerfile
+++ b/.devcontainer-java11/Dockerfile
@@ -1,0 +1,27 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.5/containers/java/.devcontainer/base.Dockerfile
+
+# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
+ARG VARIANT="17-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
+
+# [Option] Install Maven
+ARG INSTALL_MAVEN="false"
+ARG MAVEN_VERSION=""
+# [Option] Install Gradle
+ARG INSTALL_GRADLE="false"
+ARG GRADLE_VERSION=""
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
+    && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+ENV JAVA_HOME=/docker-java-home

--- a/.devcontainer-java11/devcontainer.json
+++ b/.devcontainer-java11/devcontainer.json
@@ -8,7 +8,7 @@
 			// Update the VARIANT arg to pick a Java version: 11, 17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use the -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "17-bullseye",
+			"VARIANT": "11-bullseye",
 			// Options
 			"INSTALL_MAVEN": "true",
 			"INSTALL_GRADLE": "false",

--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ mvn -v
 
 	```sh
 	cd jersey-servlet-example
-  mvn clean install
-  java -jar target/dependency/webapp-runner.jar target/*.war
+	mvn clean install
+	java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
 4. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
@@ -332,8 +332,8 @@ mvn -v
 
 	```sh
 	cd spark-servlet-example
-  mvn clean install
-  java -jar target/dependency/webapp-runner.jar target/*.war
+	mvn clean install
+	java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
 4. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
@@ -401,8 +401,8 @@ mvn -v
 
 	```sh
 	cd servlet-example
-  mvn clean install
-  java -jar target/dependency/webapp-runner.jar target/*.war
+	mvn clean install
+	java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
 4. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.

--- a/README.md
+++ b/README.md
@@ -263,10 +263,11 @@ mvn -v
 
 	```sh
 	cd jersey-servlet-example
-	mvn tomcat7:run
+  mvn clean install
+  java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
-4. Go to `http://localhost:3099/api/demo` or the port that Tomcat is running on.
+4. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
 
 In your Moesif Account, you should see event logged and monitored.
 
@@ -331,10 +332,11 @@ mvn -v
 
 	```sh
 	cd spark-servlet-example
-	mvn tomcat7:run
+  mvn clean install
+  java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
-4. Go to `http://localhost:3099/api/demo` or the port that Tomcat is running on.
+4. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
 
 In your Moesif Account, you should see event logged and monitored.
 
@@ -399,10 +401,11 @@ mvn -v
 
 	```sh
 	cd servlet-example
-	mvn tomcat7:run
+  mvn clean install
+  java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
-4. Go to `http://localhost:3099/api/demo` or the port that Tomcat is running on.
+4. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
 
 In your Moesif Account, you should see event logged and monitored.
 

--- a/jersey-servlet-example/README.md
+++ b/jersey-servlet-example/README.md
@@ -58,7 +58,7 @@ mvn -v
 4. Run jersey-servlet-example
 
 	```sh
-  java -jar target/dependency/webapp-runner.jar target/*.war
+ 	java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
 5. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.

--- a/jersey-servlet-example/README.md
+++ b/jersey-servlet-example/README.md
@@ -58,10 +58,10 @@ mvn -v
 4. Run jersey-servlet-example
 
 	```sh
-	mvn tomcat7:run
+  java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
-5. Go to `http://localhost:3099/api/demo` or the port that Tomcat is running on.
+5. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
 
 In your Moesif Account, you should see API calls logged under API Analytics -> Live Event Stream.
 

--- a/jersey-servlet-example/pom.xml
+++ b/jersey-servlet-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.moesif.servlet.jersey</groupId>
     <artifactId>jersey-servlet-example</artifactId>
     <packaging>war</packaging>
-    <version>1.2.8</version>
+    <version>1.2.9</version>
     <name>jersey-servlet-example</name>
 
     <build>
@@ -15,21 +15,44 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.tomcat.maven</groupId>
-                <artifactId>tomcat7-maven-plugin</artifactId>
-                <configuration>
-                    <path>/</path>
-                    <port>3099</port>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                    <goal>copy</goal>
+                    </goals>
+                    <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                        <groupId>com.heroku</groupId>
+                        <artifactId>webapp-runner-main</artifactId>
+                        <version>8.5.68.1</version>
+                        <destFileName>webapp-runner.jar</destFileName>
+                        </artifactItem>
+                    </artifactItems>
+                    </configuration>
+                </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -57,6 +80,13 @@
             <artifactId>jersey-media-multipart</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
         <!-- uncomment this to get JSON support
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
@@ -66,11 +96,28 @@
         <dependency>
             <groupId>com.moesif.servlet</groupId>
             <artifactId>moesif-servlet</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.6</version>
+        </dependency>
+
     </dependencies>
     <properties>
-        <jersey.version>2.26-b03</jersey.version>
+        <jersey.version>2.37</jersey.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/servlet-example/README.md
+++ b/servlet-example/README.md
@@ -63,7 +63,7 @@ mvn -v
 4. Run servlet-example
 
 	```sh
-  java -jar target/dependency/webapp-runner.jar target/*.war
+ 	java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
 5. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.

--- a/servlet-example/README.md
+++ b/servlet-example/README.md
@@ -63,10 +63,10 @@ mvn -v
 4. Run servlet-example
 
 	```sh
-	mvn tomcat7:run
+  java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
-5. Go to `http://localhost:3099/api/demo` or the port that Tomcat is running on.
+5. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
 
 In your Moesif Account, you should see API calls logged under API Analytics -> Live Event Stream.
 

--- a/servlet-example/pom.xml
+++ b/servlet-example/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moesif.servlet</groupId>
   <artifactId>servlet-example</artifactId>
-  <version>1.3.7</version>
+  <version>1.3.8</version>
   <packaging>war</packaging>
   <name>servlet-example</name>
 
@@ -28,12 +28,13 @@
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.5</version>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -42,14 +43,37 @@
           <target>${java.version}</target>
         </configuration>
       </plugin>
+
       <plugin>
-        <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat7-maven-plugin</artifactId>
-        <configuration>
-          <path>/</path>
-          <port>3099</port>
-        </configuration>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.3.2</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.heroku</groupId>
+                  <artifactId>webapp-runner-main</artifactId>
+                  <version>8.5.68.1</version>
+                  <destFileName>webapp-runner.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/spark-servlet-example/README.md
+++ b/spark-servlet-example/README.md
@@ -66,7 +66,7 @@ mvn -v
 4. Run spark-servlet-example
 
 	```sh
-  java -jar target/dependency/webapp-runner.jar target/*.war
+ 	java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
 5. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.

--- a/spark-servlet-example/README.md
+++ b/spark-servlet-example/README.md
@@ -66,10 +66,10 @@ mvn -v
 4. Run spark-servlet-example
 
 	```sh
-	mvn tomcat7:run
+  java -jar target/dependency/webapp-runner.jar target/*.war
 	```
 
-5. Go to `http://localhost:3099/api/demo` or the port that Tomcat is running on.
+5. Go to `http://localhost:8080/api/demo` or the port that Tomcat is running on.
 
 In your Moesif Account, you should see API calls logged under API Analytics -> Live Event Stream.
 

--- a/spark-servlet-example/pom.xml
+++ b/spark-servlet-example/pom.xml
@@ -6,30 +6,54 @@
     <groupId>com.moesif.servlet.spark</groupId>
     <artifactId>spark-servlet-example</artifactId>
     <packaging>war</packaging>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <name>spark-servlet-example</name>
 
     <build>
         <finalName>spark-servlet-example</finalName>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.tomcat.maven</groupId>
-                <artifactId>tomcat7-maven-plugin</artifactId>
-                <configuration>
-                    <path>/</path>
-                    <port>3099</port>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                    <goal>copy</goal>
+                    </goals>
+                    <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                        <groupId>com.heroku</groupId>
+                        <artifactId>webapp-runner-main</artifactId>
+                        <version>8.5.68.1</version>
+                        <destFileName>webapp-runner.jar</destFileName>
+                        </artifactItem>
+                    </artifactItems>
+                    </configuration>
+                </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -52,18 +76,18 @@
         <dependency>
             <groupId>com.moesif.servlet</groupId>
             <artifactId>moesif-servlet</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.0-b07</version>
+            <version>4.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>

--- a/spring-boot-servlet-example/README.md
+++ b/spring-boot-servlet-example/README.md
@@ -31,9 +31,9 @@ mvn -v
 
 4. Run spring-boot-servlet-example (from the spring-boot-servlet-example dir)
 
-  ```sh
-  java -jar target/dependency/webapp-runner.jar target/*.war
-  ```
+	```sh
+ 	java -jar target/dependency/webapp-runner.jar target/*.war
+	```
 
 
 5. Using Postman or CURL, make a few API calls to `http://localhost:8080/api` or the port that Spring Boot is running on.

--- a/spring-boot-servlet-example/README.md
+++ b/spring-boot-servlet-example/README.md
@@ -31,9 +31,9 @@ mvn -v
 
 4. Run spring-boot-servlet-example (from the spring-boot-servlet-example dir)
 
-	```sh
-        java -jar target/dependency/webapp-runner.jar target/*.war
-	```
+  ```sh
+  java -jar target/dependency/webapp-runner.jar target/*.war
+  ```
 
 
 5. Using Postman or CURL, make a few API calls to `http://localhost:8080/api` or the port that Spring Boot is running on.

--- a/spring-boot-servlet-example/pom.xml
+++ b/spring-boot-servlet-example/pom.xml
@@ -6,11 +6,11 @@
   <artifactId>spring-boot-servlet-example</artifactId>
   <name>spring-boot-servlet-example</name>
   <packaging>war</packaging>
-  <version>1.3.7</version>
+  <version>2.0.0</version>
 
   <properties>
-    <springframework.version>5.3.18</springframework.version>
-    <springconfiguration.version>2.6.1</springconfiguration.version>
+    <springframework.version>5.3.23</springframework.version>
+    <springconfiguration.version>2.7.4</springconfiguration.version>
   </properties>
 
   <dependencies>
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>com.moesif.springrequest</groupId>
       <artifactId>moesif-springrequest</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.16</version>
     </dependency>
 
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.5</version>
     </dependency>
 
 
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.4.1</version>
+      <version>1.7</version>
     </dependency>
 
     <dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-      <version>8.5.65</version>
+      <version>8.5.82</version>
     </dependency>
   </dependencies>
 
@@ -92,33 +92,26 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.3.2</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat7-maven-plugin</artifactId>
-        <version>2.2</version>
-        <configuration>
-          <path>/</path>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -128,9 +121,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>com.github.jsimone</groupId>
-                  <artifactId>webapp-runner</artifactId>
-                  <version>8.5.23.0</version>
+                  <groupId>com.heroku</groupId>
+                  <artifactId>webapp-runner-main</artifactId>
+                  <version>8.5.68.1</version>
                   <destFileName>webapp-runner.jar</destFileName>
                 </artifactItem>
               </artifactItems>
@@ -138,6 +131,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 </project>

--- a/spring-boot-starter-example/pom.xml
+++ b/spring-boot-starter-example/pom.xml
@@ -6,12 +6,12 @@
   <artifactId>spring-boot-starter-example</artifactId>
   <name>spring-boot-starter-example</name>
   <packaging>war</packaging>
-  <version>1.3.7</version>
+  <version>2.0.0</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.19.RELEASE</version>
+    <version>2.7.4</version>
   </parent>
 
   <dependencies>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.5</version>
     </dependency>
   </dependencies>
 

--- a/springrequest-example/pom.xml
+++ b/springrequest-example/pom.xml
@@ -4,23 +4,21 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.19.RELEASE</version>
+    <version>2.7.4</version>
   </parent>
   <groupId>com.moesif.springrequestexample</groupId>
   <artifactId>springrequest-example</artifactId>
-  <version>1.3.4</version>
+  <version>2.0.0</version>
   <name>springrequest-example</name>
   <url>http://maven.apache.org</url>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <assertj-core.version>3.1.0</assertj-core.version>
-    <commons-io.version>2.7</commons-io.version>
-    <commons-lang3.version>3.4</commons-lang3.version>
-    <jackson.version>2.8.7</jackson.version>
+    <assertj-core.version>3.23.1</assertj-core.version>
+    <commons-io.version>2.11.0</commons-io.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <junit.version>4.13.2</junit.version>
-    <logback.version>1.1.3</logback.version>
     <mockito-core.version>1.10.19</mockito-core.version>
   </properties>
 
@@ -40,15 +38,21 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.9.10</version>
-    </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.4</version>
+        </dependency>
+
     <dependency>
       <groupId>com.moesif.springrequest</groupId>
       <artifactId>moesif-springrequest</artifactId>
-      <version>1.0.15</version>
+      <version>1.0.16</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* Add support for java `17`.
* For examples, updated several dependencies to newer versions. Removed tomcat 7 runtime dependencies.
* Set default `devcontainer` to `java 17`, added java `11` devcontainer.