### PR TITLE
#186183359: Fix build and maven publish using latest version in pom.xml, fix README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the Moesif dependency to your project's pom.xml file:
 <dependency>
     <groupId>com.moesif.servlet</groupId>
     <artifactId>moesif-servlet-jakarta</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 
@@ -49,7 +49,7 @@ dependencies {
 
 // OR for newer Jakarta
 dependencies {   
-    compile 'com.moesif.servlet:moesif-servlet-jakarta:2.0.0'
+    compile 'com.moesif.servlet:moesif-servlet-jakarta:2.0.2'
 }
 ```
 

--- a/examples/spring-boot-starter-example-jakarta/pom.xml
+++ b/examples/spring-boot-starter-example-jakarta/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.moesif.servlet</groupId>
       <artifactId>moesif-servlet-jakarta</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.2</version>
     </dependency>
   </dependencies>
 

--- a/moesif-servlet-jakarta/README.md
+++ b/moesif-servlet-jakarta/README.md
@@ -24,7 +24,7 @@ Add the Moesif dependency to your project's pom.xml file:
 <dependency>
     <groupId>com.moesif.servlet</groupId>
     <artifactId>moesif-servlet-jakarta</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 
@@ -34,7 +34,7 @@ Add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
 dependencies {   
-    compile 'com.moesif.servlet:moesif-servlet-jakarta:2.0.0'
+    compile 'com.moesif.servlet:moesif-servlet-jakarta:2.0.2'
 }
 ```
 

--- a/moesif-servlet-jakarta/pom.xml
+++ b/moesif-servlet-jakarta/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.moesif.api</groupId>
       <artifactId>moesifapi</artifactId>
-      <version>1.6.18</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/moesif-springrequest/README.md
+++ b/moesif-springrequest/README.md
@@ -18,7 +18,7 @@ Add the Moesif dependency to your project's pom.xml file:
 <dependency>
     <groupId>com.moesif.springrequest</groupId>
     <artifactId>moesif-springrequest</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
 </dependency>
 ```
 
@@ -28,7 +28,7 @@ Add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
 dependencies {   
-    compile 'com.moesif.springrequest:moesif-springrequest:1.0.17'
+    compile 'com.moesif.springrequest:moesif-springrequest:1.0.18'
 }
 ```
 

--- a/moesif-springrequest/pom.xml
+++ b/moesif-springrequest/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.moesif.api</groupId>
       <artifactId>moesifapi</artifactId>
-      <version>1.6.18</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -107,7 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.1</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -132,6 +132,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -145,6 +146,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>3.0.1</version>
+        <!--
+        <configuration>
+            <skip>true</skip>
+        </configuration>
+        -->
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -165,7 +171,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>false</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
* Fix `pom.xml` to use correct versions of `com.moesif.*` as well as `plugins`
* Fix `README`(s) to refer to latest versions.